### PR TITLE
chore: remove unnecessary curl image build stage

### DIFF
--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -1,44 +1,15 @@
-FROM curlimages/curl:7.88.1 as binaryimage
-
-USER root
-
-ARG HTTPS_PROXY
-ARG HTTP_PROXY
-
-ENV http_proxy $HTTP_PROXY
-ENV https_proxy $HTTPS_PROXY
-
-ARG TARGET_PLATFORM=amd64
-
-RUN mkdir -p /tmp/bin && \
-    curl -k -L https://mirrors.chaos-mesh.org/byteman-chaos-mesh-download-v4.0.20-0.12.tar.gz -o /usr/local/byteman.tar.gz && \
-    tar xvf /usr/local/byteman.tar.gz -C /usr/local && \
-    mv /usr/local/byteman-chaos-mesh-download-v4.0.20-0.12 /tmp/byteman && \
-    rm /usr/local/byteman.tar.gz
-
-# toda doesn't support arm64 yet
-RUN curl -k -L https://github.com/chaos-mesh/toda/releases/download/v0.2.3/toda-linux-amd64.tar.gz | tar xz -C /tmp/bin
-RUN case "$TARGET_PLATFORM" in \
-    'amd64') \
-    export NSEXEC_ARCH='x86_64'; \
-    ;; \
-    'arm64') \
-    export NSEXEC_ARCH='aarch64'; \
-    ;; \
-    *) echo >&2 "error: unsupported architecture '$TARGET_PLATFORM'"; exit 1 ;; \
-    esac; \
-    curl -k -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.6/nsexec-$NSEXEC_ARCH-unknown-linux-gnu.tar.gz | tar xz -C /tmp/bin; \
-    curl -k -L https://github.com/chaos-mesh/chaos-tproxy/releases/download/v0.5.3/tproxy-$NSEXEC_ARCH.tar.gz | tar xz -C /tmp/bin; \
-    curl -k -L https://github.com/chaos-mesh/memStress/releases/download/v0.3/memStress_v0.3-$NSEXEC_ARCH-linux-gnu.tar.gz | tar xz -C /tmp/bin
-
-
-
-
-# ---
 FROM debian:bullseye-slim
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
+
+ARG TARGET_PLATFORM=amd64
+
+ARG BYTEMAN_VERSION=v4.0.20-0.12
+ARG TODA_VERSION=v0.2.3-f3-rorootfs-pre1
+ARG NSEXEC_VERSION=v0.1.6
+ARG TPROXY_VERSION=v0.5.3
+ARG MEMSTRESS_VERSION=v0.3
 
 ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
@@ -49,21 +20,42 @@ RUN apt-get update && \
     echo "deb http://security.debian.org/debian-security bullseye-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
     apt --allow-releaseinfo-change update && apt upgrade  -y && \
-    apt-get install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-11-jre && \
+    apt-get install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps curl openjdk-11-jre && \
     rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
     update-alternatives --set ebtables /usr/sbin/ebtables-legacy
 
 ENV RUST_BACKTRACE 1
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+
+RUN curl -L https://mirrors.chaos-mesh.org/byteman-chaos-mesh-download-${BYTEMAN_VERSION}.tar.gz -o /usr/local/byteman.tar.gz && \
+    tar xvf /usr/local/byteman.tar.gz -C /usr/local && \
+    mv /usr/local/byteman-chaos-mesh-download-${BYTEMAN_VERSION} /usr/local/byteman && \
+    rm /usr/local/byteman.tar.gz
+
 ENV BYTEMAN_HOME /usr/local/byteman
 ENV PATH $PATH:/usr/local/byteman/bin
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-ENV PATH $PATH:/usr/local/bin
+
+# toda doesn't support arm64 yet
+RUN case "$TARGET_PLATFORM" in \
+    'amd64') \
+    export NSEXEC_ARCH='x86_64'; \
+    ;; \
+    'arm64') \
+    export NSEXEC_ARCH='aarch64'; \
+    ;; \
+    *) echo >&2 "error: unsupported architecture '$TARGET_PLATFORM'"; exit 1 ;; \
+    esac; \
+    curl -L https://github.com/form3tech-oss/toda/releases/download/${TODA_VERSION}/toda-linux-amd64.tar.gz | tar xz -C /urs/local/bin; \
+    curl -L https://github.com/chaos-mesh/nsexec/releases/download/${NSEXEC_VERSION}/nsexec-$NSEXEC_ARCH-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin; \
+    curl -L https://github.com/chaos-mesh/chaos-tproxy/releases/download/${TPROXY_VERSION}/tproxy-$NSEXEC_ARCH.tar.gz | tar xz -C /usr/local/bin; \
+    curl -L https://github.com/chaos-mesh/memStress/releases/download/${MEMSTRESS_VERSION}/memStress_${MEMSTRESS_VERSION}-$NSEXEC_ARCH-linux-gnu.tar.gz | tar xz -C /usr/local/bin
 
 COPY bin/chaos-daemon /usr/local/bin/chaos-daemon
 COPY bin/pause /usr/local/bin/pause
 COPY bin/cdh /usr/local/bin/cdh
-COPY --from=binaryimage /tmp/byteman /usr/local/byteman
-COPY --from=binaryimage /tmp/bin/* /usr/local/bin/
+
+ENV PATH $PATH:/usr/local/bin
+
 RUN mv /usr/local/bin/libnsenter.so /usr/local/lib/libnsenter.so


### PR DESCRIPTION
Removes curl image as a build step for downloading binaries when building chaos-daemon.

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
