### PR TITLE
fix: improve zap logging configuration

### DIFF
--- a/helm/chaos-mesh/templates/_helpers.tpl
+++ b/helm/chaos-mesh/templates/_helpers.tpl
@@ -19,6 +19,28 @@ Ref: https://github.com/chaos-mesh/chaos-mesh/pull/2955.
 {{- end }}
 
 {{/*
+Handle logging configuration.
+*/}}
+{{- define "chaos-mesh.helpers.loggingEnvVars" -}}
+- name: LOG_FORMAT
+  value: {{ .logging.format | quote }}
+- name: LOG_LEVEL
+  value: {{ .logging.level | quote }}
+{{- if eq .logging.format "json" }}
+- name: LOG_TIMESTAMP_FORMAT
+  value: {{ .logging.timestampFormat | quote }}
+{{- range $k, $v :=  .logging.fieldKeys }}
+- name: LOG_KEY_{{ $k | upper }}
+  value: {{ $v | quote }}
+{{- end }}
+{{- if .logging.maxFieldSize }}
+- name: LOG_MAX_FIELD_SIZE
+  value: {{ .logging.maxFieldSize | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "chaos-mesh.name" -}}

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -100,6 +100,7 @@ spec:
             {{- if .Values.chaosDaemon.env }}
             {{- include "chaos-mesh.helpers.listEnvVars" .Values.chaosDaemon | trim | nindent 12 }}
             {{- end }}
+            {{- include "chaos-mesh.helpers.loggingEnvVars" .Values | trim | nindent 12 }}
             {{- if not .Values.chaosDaemon.env.TZ }}
             - name: TZ
               value: {{ .Values.timezone | default "UTC" }}

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -76,6 +76,7 @@ spec:
             {{- if .Values.dashboard.env }}
             {{- include "chaos-mesh.helpers.listEnvVars" .Values.dashboard | trim | nindent 12 }}
             {{- end }}
+            {{- include "chaos-mesh.helpers.loggingEnvVars" .Values | trim | nindent 12 }}
             {{- if not .Values.dashboard.env.TZ }}
             - name: TZ
               value: {{ .Values.timezone | default "UTC" }}

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -72,6 +72,7 @@ spec:
           {{- if .Values.controllerManager.env }}
           {{- include "chaos-mesh.helpers.listEnvVars" .Values.controllerManager | trim | nindent 10 }}
           {{- end }}
+          {{- include "chaos-mesh.helpers.loggingEnvVars" .Values | trim | nindent 10 }}
           - name: NAMESPACE
             valueFrom:
               fieldRef:

--- a/helm/chaos-mesh/values.schema.json
+++ b/helm/chaos-mesh/values.schema.json
@@ -632,6 +632,34 @@
                 }
             }
         },
+        "logging": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "string"
+                },
+                "timestampFormat": {
+                    "type": "string"
+                },
+                "fieldKeys": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "maxFieldSize": {
+                    "type": ["number", "null"]
+                }
+            }
+        },
         "nameOverride": {
             "type": "string"
         },

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -55,6 +55,26 @@ images:
 imagePullSecrets: []
 # - name: secretName
 
+# Log configuration shared by all deployed applications
+logging:
+  # Logging output format: "console" or "json"
+  format: console
+  # Log level to output
+  level: debug
+
+  # remaining fields only take effect if format is "json"
+
+  # Format for timestamp field: "epoch" (seconds since unix epoch, as a floating point), "rfc3339" and "rfc3339nano" (ns precision)
+  timestampFormat: epoch
+  # Allow customization of "message" and "timestamp" value keys in json output, to give consistency with other
+  # applications and/or allow proper indexing by log aggregation platforms
+  fieldKeys: {}
+    # message: msg
+    # timestamp: ts
+  # Optional configuration to determine the maximum size of a log field when serializing an object.
+  # This can be useful to avoid extremely long log entries that can cause problems with log synchronization.
+  maxFieldSize:
+
 controllerManager:
   # securityContext if needed
   securityContext: {}

--- a/install.sh
+++ b/install.sh
@@ -1628,6 +1628,10 @@ spec:
             - --runtime-socket-path
             - /host-run/${socketName}
           env:
+            - name: LOG_FORMAT
+              value: "console"
+            - name: LOG_LEVEL
+              value: "debug"
             - name: TZ
               value: ${timezone}
           securityContext:
@@ -1743,6 +1747,10 @@ spec:
               value: "336h"
             - name: TTL_WORKFLOW
               value: "336h"
+            - name: LOG_FORMAT
+              value: "console"
+            - name: LOG_LEVEL
+              value: "debug"
             - name: TZ
               value: ${timezone}
             - name: CLUSTER_SCOPED
@@ -1843,6 +1851,10 @@ spec:
             value: "10080"
           - name: WEBHOOK_PORT
             value: "10250"
+          - name: LOG_FORMAT
+            value: "console"
+          - name: LOG_LEVEL
+            value: "debug"
           - name: NAMESPACE
             valueFrom:
               fieldRef:

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -16,7 +16,11 @@
 package log
 
 import (
+	"encoding/json"
 	"io"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
@@ -24,16 +28,122 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// Environment variable to control log format, if set to JSON, structured logging will be used. Default is "console", and to use zap.NewDevelopmentConfig.
+const LogFormat = "LOG_FORMAT"
+
+// Environment variable to control logging level, should parse to zapcore.Level. Default is "info".
+const LogLevel = "LOG_LEVEL"
+
+// Environment variable to control logging key used for log message in structured logging. Default is defined by zap.NewProductionEncoderConfig.
+const LogKeyMessage = "LOG_KEY_MESSAGE"
+
+// Environment variable to control logging key used for log timestamp in structured logging. Default is defined by zap.NewProductionEncoderConfig.
+const LogKeyTimestamp = "LOG_KEY_TIMESTAMP"
+
+// Environment variable to control the maximum field size in structured logging before truncating the field value.
+const LogMaxFieldSize = "LOG_MAX_FIELD_SIZE"
+
+// Environment variable to control the logging timestamp format used in structured logging. Valid values are "rfc3339", "rfc3339nano" and "epoch".
+const LogTimestampFormat = "LOG_TIMESTAMP_FORMAT"
+
 // NewDefaultZapLogger is the recommended way to create a new logger, you could call this function to initialize the root
 // logger of your application, and provide it to your components, by fx or manually.
 func NewDefaultZapLogger() (logr.Logger, error) {
-	// change the configuration in the future if needed.
-	zapLogger, err := zap.NewDevelopment()
+	envLevel := os.Getenv(LogLevel)
+	logLevel := zap.InfoLevel
+	if envLevel != "" {
+		var err error
+		logLevel, err = zapcore.ParseLevel(envLevel)
+		if err != nil {
+			return logr.Discard(), err
+		}
+	}
+
+	envFormat := os.Getenv(LogFormat)
+	logFormat := "console"
+	if envFormat == "json" {
+		logFormat = "json"
+	}
+
+	var config zap.Config
+
+	if logFormat == "json" {
+		encoderConfig := zap.NewProductionEncoderConfig()
+
+		if v := os.Getenv(LogKeyMessage); v != "" {
+			encoderConfig.MessageKey = v
+		}
+		if v := os.Getenv(LogKeyTimestamp); v != "" {
+			encoderConfig.TimeKey = v
+		}
+
+		if v := os.Getenv(LogTimestampFormat); v != "" {
+			if v == "rfc3339" {
+				encoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+			} else if v == "rfc3339nano" {
+				encoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+			} else if v == "epoch" {
+				encoderConfig.EncodeTime = zapcore.EpochTimeEncoder
+			}
+		}
+
+		// If configured, truncate the fields to the configured size. This allows for reasonable configuration to prevent extremely
+		// long logging lines (e.g. by logging an object with a large collection of events attached), which can cause issues with
+		// log ingestion/collection, while guaranteeing that the output remains valid JSON.
+		envMaxFieldSize := os.Getenv(LogMaxFieldSize)
+		if envMaxFieldSize != "" {
+			maxFieldSize, err := strconv.Atoi(envMaxFieldSize)
+			if err == nil {
+				encoderConfig.NewReflectedEncoder = func(w io.Writer) zapcore.ReflectedEncoder {
+					enc := json.NewEncoder(newTruncatingWriter(w, maxFieldSize))
+					enc.SetEscapeHTML(false)
+					return enc
+				}
+			}
+		}
+
+		config = zap.NewProductionConfig()
+		config.EncoderConfig = encoderConfig
+	} else {
+		config = zap.NewDevelopmentConfig()
+	}
+
+	zapLogger, err := config.Build(zap.IncreaseLevel(logLevel))
 	if err != nil {
 		return logr.Discard(), err
 	}
+
 	logger := zapr.NewLogger(zapLogger)
 	return logger, nil
+}
+
+type truncatingWriter struct {
+	writer    io.Writer
+	enc       *json.Encoder
+	maxLength int
+}
+
+func newTruncatingWriter(writer io.Writer, maxLength int) truncatingWriter {
+	enc := json.NewEncoder(writer)
+	enc.SetEscapeHTML(false)
+
+	return truncatingWriter{
+		writer:    writer,
+		maxLength: maxLength,
+		enc:       enc,
+	}
+}
+
+func (tr truncatingWriter) Write(bytes []byte) (int, error) {
+	output := bytes
+
+	if len(bytes) > tr.maxLength {
+		output = append([]byte("TRUNCATED "), bytes[:tr.maxLength]...)
+	}
+
+	// Always encode the field value as a JSON string, this ensures that the log field types will not change between logging
+	// of truncated and untruncated values, while also ensuring that the log line remains valid JSON.
+	return 0, tr.enc.Encode(strings.TrimRight(string(output), "\n"))
 }
 
 // NewZapLoggerWithWriter creates a new logger with io.writer

--- a/pkg/log/zap_test.go
+++ b/pkg/log/zap_test.go
@@ -1,0 +1,355 @@
+// Copyright 2023 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
+)
+
+func TestZapLoggerSetup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Zap Logger")
+}
+
+var _ = Describe("NewDefaultZapLogger", func() {
+	Context("no environment", func() {
+		It("uses console output", func() {
+			var logTime time.Time
+
+			output, err := interceptLogging(func() {
+				logger, err := log.NewDefaultZapLogger()
+				Expect(err).NotTo(HaveOccurred())
+
+				logTime = time.Now().Truncate(time.Second)
+				logger.Info("test", "key", "value123")
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			fields := strings.Fields(output)
+
+			if len(fields) < 5 {
+				Expect(len(fields)).To(BeNumerically(">=", 5))
+			}
+
+			// Default is ISO8601, painfully close to but not the same as RFC3339
+			ts, err := time.Parse("2006-01-02T15:04:05Z0700", fields[0])
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ts.Before(logTime)).To(BeFalse())
+			Expect(ts.After(time.Now())).To(BeFalse())
+
+			Expect(fields[1]).To(Equal("INFO"))
+			Expect(fields[2]).To(HavePrefix("log/zap_test.go:"))
+
+			message := strings.TrimSpace(strings.Join(fields[3:], " "))
+			Expect(message).To(Equal(`test {"key": "value123"}`))
+		})
+	})
+
+	Context("JSON format", func() {
+		It("logs valid JSON", func() {
+			var logTime int64
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					logTime = time.Now().UnixNano()
+					logger.Info("test", "key", "value123")
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("ts"))
+			tsSeconds := math.Floor(data["ts"].(float64))
+			tsNanos := int64((data["ts"].(float64) - tsSeconds) * float64(time.Second))
+			ts := int64(tsSeconds)*int64(time.Second) + tsNanos
+			Expect(ts).To(BeNumerically(">", logTime))
+			Expect(ts).To(BeNumerically("<", time.Now().UnixNano()))
+
+			Expect(data).To(HaveKey("level"))
+			Expect(data["level"]).To(Equal("info"))
+
+			Expect(data).To(HaveKey("msg"))
+			Expect(data["msg"]).To(Equal("test"))
+
+			Expect(data).To(HaveKey("caller"))
+			Expect(data["caller"]).To(HavePrefix("log/zap_test.go:"))
+
+			Expect(data).To(HaveKey("key"))
+			Expect(data["key"]).To(Equal("value123"))
+		})
+
+		It("uses configured timestamp key", func() {
+			var logTime int64
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json", log.LogKeyTimestamp: "timestamp"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					logTime = time.Now().UnixNano()
+					logger.Info("test", "key", "value123")
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("timestamp"))
+			tsSeconds := math.Floor(data["timestamp"].(float64))
+			tsNanos := int64((data["timestamp"].(float64) - tsSeconds) * float64(time.Second))
+			ts := int64(tsSeconds)*int64(time.Second) + tsNanos
+			Expect(ts).To(BeNumerically(">=", logTime))
+			Expect(ts).To(BeNumerically("<", time.Now().UnixNano()))
+		})
+
+		It("uses configured message key", func() {
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json", log.LogKeyMessage: "message"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					logger.Info("test", "key", "value123")
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("message"))
+			Expect(data["message"]).To(Equal("test"))
+		})
+
+		It("uses configured timestamp format", func() {
+			var logTime time.Time
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json", log.LogTimestampFormat: "rfc3339nano"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					logTime = time.Now()
+					logger.Info("test", "key", "value123")
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("ts"))
+			ts, err := time.Parse(time.RFC3339Nano, data["ts"].(string))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ts.After(logTime)).To(BeTrue())
+			Expect(ts.Before(time.Now())).To(BeTrue())
+		})
+
+		It("respects LOG_LEVEL", func() {
+			var output string
+
+			wrapEnv(map[string]string{log.LogLevel: "error"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					logger.Info("test", "key", "value123")
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Expect(output).To(Equal(""))
+
+			wrapEnv(map[string]string{log.LogLevel: "info"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					logger.Info("test", "key", "value123")
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Expect(output).NotTo(Equal(""))
+		})
+
+		It("logs interface{} objects", func() {
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					type testStruct struct {
+						String string
+						Int    int
+					}
+
+					logger.Info("test", "obj", testStruct{String: "hello!", Int: 42})
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("obj"))
+			Expect(data["obj"]).To(Equal(map[string]interface{}{"String": "hello!", "Int": float64(42)}))
+		})
+
+		It("logs interface{} objects as JSON string with truncation enabled", func() {
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json", log.LogMaxFieldSize: "100"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					type testStruct struct {
+						String string
+						Int    int
+					}
+
+					logger.Info("test", "obj", testStruct{String: "hello!", Int: 42})
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("obj"))
+			Expect(data["obj"]).To(Equal(`{"String":"hello!","Int":42}`))
+		})
+
+		It("truncates large logged objects", func() {
+			var output string
+
+			wrapEnv(map[string]string{log.LogFormat: "json", log.LogMaxFieldSize: "100"}, func() {
+				var err error
+				output, err = interceptLogging(func() {
+					logger, err := log.NewDefaultZapLogger()
+					Expect(err).NotTo(HaveOccurred())
+
+					type testStruct struct {
+						String string
+						Int    int
+					}
+					object := []testStruct{}
+					for i := 0; i < 20; i++ {
+						object = append(object, testStruct{String: fmt.Sprintf("struct #%d", i), Int: i})
+					}
+
+					logger.Info("test", "obj", object)
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			var data map[string]interface{}
+			err := json.Unmarshal([]byte(output), &data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(data).To(HaveKey("obj"))
+			Expect(data["obj"]).To(HaveLen(110))
+			Expect(data["obj"]).To(HavePrefix("TRUNCATED "))
+		})
+	})
+})
+
+func interceptLogging(f func()) (string, error) {
+	stderr := os.Stderr
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", fmt.Errorf("pipe creation: %w", err)
+	}
+	os.Stderr = w
+
+	f()
+
+	os.Stderr = stderr
+	w.Close()
+
+	output, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("read from pipe: %w", err)
+	}
+
+	return string(output), nil
+}
+
+func wrapEnv(values map[string]string, f func()) {
+	saved := map[string]string{}
+
+	for k, v := range values {
+		existing, set := os.LookupEnv(k)
+		if set {
+			saved[k] = existing
+		}
+
+		os.Setenv(k, v)
+	}
+	defer func() {
+		for k := range values {
+			if existing, ok := saved[k]; ok {
+				os.Setenv(k, existing)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}()
+
+	f()
+
+}


### PR DESCRIPTION
The original aim here was to prevent log lines long enough to cause `fluentd` to fail to ingest logs. After working out a solution, it became apparent that more logging configuration would also be desirable.

Configure structured logging and conventional field names for timestamp, level, etc.

Truncate log fields over a certain limit.

Allow configuration of key logging parameters through environment.

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
