### PR TITLE
fix: don't spawn new workflow child on abort

### DIFF
--- a/pkg/workflow/controllers/serial_node_reconciler.go
+++ b/pkg/workflow/controllers/serial_node_reconciler.go
@@ -178,6 +178,15 @@ func (it *SerialNodeReconciler) syncChildNodes(ctx context.Context, node v1alpha
 	if err != nil {
 		return err
 	}
+
+	if abortedStatusCheck := findAbortedStatusCheckNode(finishedChildNodes); abortedStatusCheck != nil {
+		it.logger.Info(
+			"not spawning new child, status check node with status aborted and AbortWithStatusCheck = true",
+			"node",
+			fmt.Sprintf("%s/%s", abortedStatusCheck.Namespace, abortedStatusCheck.Name),
+		)
+	}
+
 	var taskToStartup string
 	if len(activeChildNodes) == 0 {
 		// no active children, trying to spawn a new one
@@ -285,5 +294,18 @@ func (it *SerialNodeReconciler) syncChildNodes(ctx context.Context, node v1alpha
 		"node", fmt.Sprintf("%s/%s", node.Namespace, node.Name),
 		"child node", childrenNames)
 
+	return nil
+}
+
+func findAbortedStatusCheckNode(nodes []v1alpha1.WorkflowNode) *v1alpha1.WorkflowNode {
+	for _, node := range nodes {
+		if node.Spec.Type == v1alpha1.TypeStatusCheck && node.Spec.AbortWithStatusCheck {
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == v1alpha1.ConditionAborted && cond.Status == corev1.ConditionTrue {
+					return &node
+				}
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
If status check node aborted and has "abort with statuscheck" flag set, don't spawn a new workflow child node for the next step.

This fixes a race condition where the serial reconciler spawns a new child node in the window between the statuscheck node aborting and the abort status being propagated to the parent.

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
