### PR TITLE
fix: k8sChaos duration should be optional

### DIFF
--- a/api/v1alpha1/k8schaos_types.go
+++ b/api/v1alpha1/k8schaos_types.go
@@ -46,7 +46,8 @@ var (
 // K8SChaosSpec defines the desired state of K8SChaos
 type K8SChaosSpec struct {
 	// Duration represents the duration of the chaos action
-	Duration *string `json:"duration" webhook:"Duration"`
+	// +optional
+	Duration *string `json:"duration,omitempty" webhook:"Duration"`
 
 	// +kubebuilder:validation:Required
 	APIObjects *K8SChaosAPIObjects `json:"apiObjects"`

--- a/config/crd/bases/chaos-mesh.org_k8schaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_k8schaos.yaml
@@ -57,7 +57,6 @@ spec:
                 type: string
             required:
             - apiObjects
-            - duration
             type: object
           status:
             description: Most recently observed status of the chaos experiment about

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -1494,7 +1494,6 @@ spec:
                     type: string
                 required:
                 - apiObjects
-                - duration
                 type: object
               kernelChaos:
                 description: KernelChaosSpec defines the desired state of KernelChaos
@@ -5192,7 +5191,6 @@ spec:
                               type: string
                           required:
                           - apiObjects
-                          - duration
                           type: object
                         kernelChaos:
                           description: KernelChaosSpec defines the desired state of
@@ -8672,7 +8670,6 @@ spec:
                                   type: string
                               required:
                               - apiObjects
-                              - duration
                               type: object
                             kernelChaos:
                               description: KernelChaosSpec defines the desired state

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -1515,7 +1515,6 @@ spec:
                     type: string
                 required:
                 - apiObjects
-                - duration
                 type: object
               kernelChaos:
                 description: KernelChaosSpec defines the desired state of KernelChaos
@@ -4776,7 +4775,6 @@ spec:
                         type: string
                     required:
                     - apiObjects
-                    - duration
                     type: object
                   kernelChaos:
                     description: KernelChaosSpec defines the desired state of KernelChaos
@@ -8560,7 +8558,6 @@ spec:
                                   type: string
                               required:
                               - apiObjects
-                              - duration
                               type: object
                             kernelChaos:
                               description: KernelChaosSpec defines the desired state
@@ -12151,7 +12148,6 @@ spec:
                                       type: string
                                   required:
                                   - apiObjects
-                                  - duration
                                   type: object
                                 kernelChaos:
                                   description: KernelChaosSpec defines the desired

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -1573,7 +1573,6 @@ spec:
                           type: string
                       required:
                       - apiObjects
-                      - duration
                       type: object
                     kernelChaos:
                       description: KernelChaosSpec defines the desired state of KernelChaos
@@ -4958,7 +4957,6 @@ spec:
                               type: string
                           required:
                           - apiObjects
-                          - duration
                           type: object
                         kernelChaos:
                           description: KernelChaosSpec defines the desired state of

--- a/helm/chaos-mesh/crds/chaos-mesh.org_k8schaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_k8schaos.yaml
@@ -57,7 +57,6 @@ spec:
                 type: string
             required:
             - apiObjects
-            - duration
             type: object
           status:
             description: Most recently observed status of the chaos experiment about

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -1494,7 +1494,6 @@ spec:
                     type: string
                 required:
                 - apiObjects
-                - duration
                 type: object
               kernelChaos:
                 description: KernelChaosSpec defines the desired state of KernelChaos
@@ -5192,7 +5191,6 @@ spec:
                               type: string
                           required:
                           - apiObjects
-                          - duration
                           type: object
                         kernelChaos:
                           description: KernelChaosSpec defines the desired state of
@@ -8672,7 +8670,6 @@ spec:
                                   type: string
                               required:
                               - apiObjects
-                              - duration
                               type: object
                             kernelChaos:
                               description: KernelChaosSpec defines the desired state

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -1515,7 +1515,6 @@ spec:
                     type: string
                 required:
                 - apiObjects
-                - duration
                 type: object
               kernelChaos:
                 description: KernelChaosSpec defines the desired state of KernelChaos
@@ -4776,7 +4775,6 @@ spec:
                         type: string
                     required:
                     - apiObjects
-                    - duration
                     type: object
                   kernelChaos:
                     description: KernelChaosSpec defines the desired state of KernelChaos
@@ -8560,7 +8558,6 @@ spec:
                                   type: string
                               required:
                               - apiObjects
-                              - duration
                               type: object
                             kernelChaos:
                               description: KernelChaosSpec defines the desired state
@@ -12151,7 +12148,6 @@ spec:
                                       type: string
                                   required:
                                   - apiObjects
-                                  - duration
                                   type: object
                                 kernelChaos:
                                   description: KernelChaosSpec defines the desired

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -1573,7 +1573,6 @@ spec:
                           type: string
                       required:
                       - apiObjects
-                      - duration
                       type: object
                     kernelChaos:
                       description: KernelChaosSpec defines the desired state of KernelChaos
@@ -4958,7 +4957,6 @@ spec:
                               type: string
                           required:
                           - apiObjects
-                          - duration
                           type: object
                         kernelChaos:
                           description: KernelChaosSpec defines the desired state of

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -2773,7 +2773,6 @@ spec:
                 type: string
             required:
             - apiObjects
-            - duration
             type: object
           status:
             description: Most recently observed status of the chaos experiment about
@@ -7712,7 +7711,6 @@ spec:
                     type: string
                 required:
                 - apiObjects
-                - duration
                 type: object
               kernelChaos:
                 description: KernelChaosSpec defines the desired state of KernelChaos
@@ -11410,7 +11408,6 @@ spec:
                               type: string
                           required:
                           - apiObjects
-                          - duration
                           type: object
                         kernelChaos:
                           description: KernelChaosSpec defines the desired state of
@@ -14890,7 +14887,6 @@ spec:
                                   type: string
                               required:
                               - apiObjects
-                              - duration
                               type: object
                             kernelChaos:
                               description: KernelChaosSpec defines the desired state
@@ -24835,7 +24831,6 @@ spec:
                     type: string
                 required:
                 - apiObjects
-                - duration
                 type: object
               kernelChaos:
                 description: KernelChaosSpec defines the desired state of KernelChaos
@@ -28096,7 +28091,6 @@ spec:
                         type: string
                     required:
                     - apiObjects
-                    - duration
                     type: object
                   kernelChaos:
                     description: KernelChaosSpec defines the desired state of KernelChaos
@@ -31880,7 +31874,6 @@ spec:
                                   type: string
                               required:
                               - apiObjects
-                              - duration
                               type: object
                             kernelChaos:
                               description: KernelChaosSpec defines the desired state
@@ -35471,7 +35464,6 @@ spec:
                                       type: string
                                   required:
                                   - apiObjects
-                                  - duration
                                   type: object
                                 kernelChaos:
                                   description: KernelChaosSpec defines the desired
@@ -49778,7 +49770,6 @@ spec:
                           type: string
                       required:
                       - apiObjects
-                      - duration
                       type: object
                     kernelChaos:
                       description: KernelChaosSpec defines the desired state of KernelChaos
@@ -53163,7 +53154,6 @@ spec:
                               type: string
                           required:
                           - apiObjects
-                          - duration
                           type: object
                         kernelChaos:
                           description: KernelChaosSpec defines the desired state of

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -6583,7 +6583,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/v1alpha1.K8SChaosAPIObjects"
                 },
                 "duration": {
-                    "description": "Duration represents the duration of the chaos action",
+                    "description": "Duration represents the duration of the chaos action\n+optional",
                     "type": "string"
                 },
                 "remoteCluster": {

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -6575,7 +6575,7 @@
                     "$ref": "#/definitions/v1alpha1.K8SChaosAPIObjects"
                 },
                 "duration": {
-                    "description": "Duration represents the duration of the chaos action",
+                    "description": "Duration represents the duration of the chaos action\n+optional",
                     "type": "string"
                 },
                 "remoteCluster": {

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -5068,7 +5068,9 @@ definitions:
         $ref: '#/definitions/v1alpha1.K8SChaosAPIObjects'
         description: +kubebuilder:validation:Required
       duration:
-        description: Duration represents the duration of the chaos action
+        description: |-
+          Duration represents the duration of the chaos action
+          +optional
         type: string
       remoteCluster:
         description: |-


### PR DESCRIPTION

## What problem does this PR solve?

Duration must be optional, I think we lost this fix in the upstream sync / rebase before christmas
