### PR TITLE
fix: cilium chaos duration should be optional

### DIFF
--- a/api/v1alpha1/ciliumchaos_types.go
+++ b/api/v1alpha1/ciliumchaos_types.go
@@ -42,7 +42,8 @@ type CiliumChaosSpec struct {
 	NodeSelector `json:",inline"`
 
 	// Duration represents the duration of the chaos action.
-	Duration *string `json:"duration" webhook:"Duration"`
+	// +optional
+	Duration *string `json:"duration,omitempty" webhook:"Duration"`
 
 	// CiliumPodSelector provides a custom selector to find the cilium-agent pod for the node.
 	//

--- a/config/crd/bases/chaos-mesh.org_ciliumchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_ciliumchaos.yaml
@@ -122,7 +122,6 @@ spec:
                 type: string
             required:
             - ciliumPodSelector
-            - duration
             - mode
             - selector
             type: object

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -371,7 +371,6 @@ spec:
                     type: string
                 required:
                 - ciliumPodSelector
-                - duration
                 - mode
                 - selector
                 type: object
@@ -3984,7 +3983,6 @@ spec:
                               type: string
                           required:
                           - ciliumPodSelector
-                          - duration
                           - mode
                           - selector
                           type: object
@@ -7445,7 +7443,6 @@ spec:
                                   type: string
                               required:
                               - ciliumPodSelector
-                              - duration
                               - mode
                               - selector
                               type: object

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -381,7 +381,6 @@ spec:
                     type: string
                 required:
                 - ciliumPodSelector
-                - duration
                 - mode
                 - selector
                 type: object
@@ -3621,7 +3620,6 @@ spec:
                         type: string
                     required:
                     - ciliumPodSelector
-                    - duration
                     - mode
                     - selector
                     type: object
@@ -7318,7 +7316,6 @@ spec:
                                   type: string
                               required:
                               - ciliumPodSelector
-                              - duration
                               - mode
                               - selector
                               type: object
@@ -10882,7 +10879,6 @@ spec:
                                       type: string
                                   required:
                                   - ciliumPodSelector
-                                  - duration
                                   - mode
                                   - selector
                                   type: object

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -399,7 +399,6 @@ spec:
                           type: string
                       required:
                       - ciliumPodSelector
-                      - duration
                       - mode
                       - selector
                       type: object
@@ -3764,7 +3763,6 @@ spec:
                               type: string
                           required:
                           - ciliumPodSelector
-                          - duration
                           - mode
                           - selector
                           type: object

--- a/helm/chaos-mesh/crds/chaos-mesh.org_ciliumchaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_ciliumchaos.yaml
@@ -122,7 +122,6 @@ spec:
                 type: string
             required:
             - ciliumPodSelector
-            - duration
             - mode
             - selector
             type: object

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -371,7 +371,6 @@ spec:
                     type: string
                 required:
                 - ciliumPodSelector
-                - duration
                 - mode
                 - selector
                 type: object
@@ -3984,7 +3983,6 @@ spec:
                               type: string
                           required:
                           - ciliumPodSelector
-                          - duration
                           - mode
                           - selector
                           type: object
@@ -7445,7 +7443,6 @@ spec:
                                   type: string
                               required:
                               - ciliumPodSelector
-                              - duration
                               - mode
                               - selector
                               type: object

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -381,7 +381,6 @@ spec:
                     type: string
                 required:
                 - ciliumPodSelector
-                - duration
                 - mode
                 - selector
                 type: object
@@ -3621,7 +3620,6 @@ spec:
                         type: string
                     required:
                     - ciliumPodSelector
-                    - duration
                     - mode
                     - selector
                     type: object
@@ -7318,7 +7316,6 @@ spec:
                                   type: string
                               required:
                               - ciliumPodSelector
-                              - duration
                               - mode
                               - selector
                               type: object
@@ -10882,7 +10879,6 @@ spec:
                                       type: string
                                   required:
                                   - ciliumPodSelector
-                                  - duration
                                   - mode
                                   - selector
                                   type: object

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -399,7 +399,6 @@ spec:
                           type: string
                       required:
                       - ciliumPodSelector
-                      - duration
                       - mode
                       - selector
                       type: object
@@ -3764,7 +3763,6 @@ spec:
                               type: string
                           required:
                           - ciliumPodSelector
-                          - duration
                           - mode
                           - selector
                           type: object

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -756,7 +756,6 @@ spec:
                 type: string
             required:
             - ciliumPodSelector
-            - duration
             - mode
             - selector
             type: object
@@ -6588,7 +6587,6 @@ spec:
                     type: string
                 required:
                 - ciliumPodSelector
-                - duration
                 - mode
                 - selector
                 type: object
@@ -10201,7 +10199,6 @@ spec:
                               type: string
                           required:
                           - ciliumPodSelector
-                          - duration
                           - mode
                           - selector
                           type: object
@@ -13662,7 +13659,6 @@ spec:
                                   type: string
                               required:
                               - ciliumPodSelector
-                              - duration
                               - mode
                               - selector
                               type: object
@@ -23697,7 +23693,6 @@ spec:
                     type: string
                 required:
                 - ciliumPodSelector
-                - duration
                 - mode
                 - selector
                 type: object
@@ -26937,7 +26932,6 @@ spec:
                         type: string
                     required:
                     - ciliumPodSelector
-                    - duration
                     - mode
                     - selector
                     type: object
@@ -30634,7 +30628,6 @@ spec:
                                   type: string
                               required:
                               - ciliumPodSelector
-                              - duration
                               - mode
                               - selector
                               type: object
@@ -34198,7 +34191,6 @@ spec:
                                       type: string
                                   required:
                                   - ciliumPodSelector
-                                  - duration
                                   - mode
                                   - selector
                                   type: object
@@ -48596,7 +48588,6 @@ spec:
                           type: string
                       required:
                       - ciliumPodSelector
-                      - duration
                       - mode
                       - selector
                       type: object
@@ -51961,7 +51952,6 @@ spec:
                               type: string
                           required:
                           - ciliumPodSelector
-                          - duration
                           - mode
                           - selector
                           type: object

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -5534,7 +5534,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/v1alpha1.CiliumPodSelectorSpec"
                 },
                 "duration": {
-                    "description": "Duration represents the duration of the chaos action.",
+                    "description": "Duration represents the duration of the chaos action.\n+optional",
                     "type": "string"
                 },
                 "mode": {

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -5526,7 +5526,7 @@
                     "$ref": "#/definitions/v1alpha1.CiliumPodSelectorSpec"
                 },
                 "duration": {
-                    "description": "Duration represents the duration of the chaos action.",
+                    "description": "Duration represents the duration of the chaos action.\n+optional",
                     "type": "string"
                 },
                 "mode": {

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -3965,7 +3965,9 @@ definitions:
           `app.kubernetes.io/name=cilium-agent` and `app.kubernetes.io/part-of=cilium` (which are used by default by the cilium
           helm chart)
       duration:
-        description: Duration represents the duration of the chaos action.
+        description: |-
+          Duration represents the duration of the chaos action.
+          +optional
         type: string
       mode:
         description: |-


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
