### PR TITLE
feat: Make createing chaos-deamon optional in helm chart

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+{{- if .Values.chaosDaemon.create }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -213,3 +214,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+{{- if .Values.chaosDaemon.create }}
 {{- if .Values.chaosDaemon.serviceAccount }}
 ---
 kind: ServiceAccount
@@ -132,4 +133,4 @@ spec:
   - secret
   - hostPath
 {{- end }}
-
+{{- end }}

--- a/helm/chaos-mesh/templates/chaos-daemon-service.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-service.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+{{- if .Values.chaosDaemon.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -43,3 +44,4 @@ spec:
   selector:
     {{- include "chaos-mesh.selectors" . | nindent 4 }}
     app.kubernetes.io/component: chaos-daemon
+{{- end }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -180,6 +180,8 @@ controllerManager:
         type: DirectoryOrCreate
 
 chaosDaemon:
+  # Enable chaos-daemon
+  create: true
   # image would be constructed by <registry>/<repository>:<tag>
   image:
     # override global registry, empty value means using the global images.registry


### PR DESCRIPTION

## What problem does this PR solve?

We want to deploy chaos-mesh without the chaos-deamon.


## What's changed and how it works?
Added `chaosDaemon.create` option in values file, which is set to `true` by default.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
