### PR TITLE
chore: Improve handling of unchanged certificates

### DIFF
--- a/api/v1alpha1/certificatechaos_types.go
+++ b/api/v1alpha1/certificatechaos_types.go
@@ -48,20 +48,15 @@ type CertificateChaosSpec struct {
 	// Duration represents the duration of the chaos action.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// +optional
-	// +kubebuilder:default="90m"
 	Duration *string `json:"duration,omitempty" webhook:"Duration"`
 
 	// CertificateExpiry represents the expiry period for the requested certificate.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	// +optional
-	// +kubebuilder:default="1h"
-	CertificateExpiry *metav1.Duration `json:"certificateExpiry,omitempty"`
+	CertificateExpiry *metav1.Duration `json:"certificateExpiry"`
 
 	// RenewBefore represents when the cert-manager should rotate the certificate.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	// +optional
-	// +kubebuilder:default="30m"
-	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
+	RenewBefore *metav1.Duration `json:"renewBefore"`
 
 	// RemoteCluster represents the remote cluster where the chaos will be deployed
 	// +optional

--- a/config/crd/bases/chaos-mesh.org_certificatechaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_certificatechaos.yaml
@@ -35,13 +35,11 @@ spec:
             description: Spec defines the behavior of a certificate chaos experiment
             properties:
               certificateExpiry:
-                default: 1h
                 description: CertificateExpiry represents the expiry period for the
                   requested certificate. Valid time units are "ns", "us" (or "µs"),
                   "ms", "s", "m", "h".
                 type: string
               duration:
-                default: 90m
                 description: Duration represents the duration of the chaos action.
                   Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                 type: string
@@ -50,7 +48,6 @@ spec:
                   chaos will be deployed
                 type: string
               renewBefore:
-                default: 30m
                 description: RenewBefore represents when the cert-manager should rotate
                   the certificate. Valid time units are "ns", "us" (or "µs"), "ms",
                   "s", "m", "h".
@@ -115,6 +112,8 @@ spec:
                     type: array
                 type: object
             required:
+            - certificateExpiry
+            - renewBefore
             - selector
             type: object
           status:

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -283,13 +283,11 @@ spec:
                   creates on a chaos experiment about pods.
                 properties:
                   certificateExpiry:
-                    default: 1h
                     description: CertificateExpiry represents the expiry period for
                       the requested certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
                     type: string
                   duration:
-                    default: 90m
                     description: Duration represents the duration of the chaos action.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     type: string
@@ -298,7 +296,6 @@ spec:
                       the chaos will be deployed
                     type: string
                   renewBefore:
-                    default: 30m
                     description: RenewBefore represents when the cert-manager should
                       rotate the certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
@@ -363,6 +360,8 @@ spec:
                         type: array
                     type: object
                 required:
+                - certificateExpiry
+                - renewBefore
                 - selector
                 type: object
               ciliumChaos:
@@ -4109,13 +4108,11 @@ spec:
                             that a user creates on a chaos experiment about pods.
                           properties:
                             certificateExpiry:
-                              default: 1h
                               description: CertificateExpiry represents the expiry
                                 period for the requested certificate. Valid time units
                                 are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                               type: string
                             duration:
-                              default: 90m
                               description: Duration represents the duration of the
                                 chaos action. Valid time units are "ns", "us" (or
                                 "µs"), "ms", "s", "m", "h".
@@ -4125,7 +4122,6 @@ spec:
                                 where the chaos will be deployed
                               type: string
                             renewBefore:
-                              default: 30m
                               description: RenewBefore represents when the cert-manager
                                 should rotate the certificate. Valid time units are
                                 "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -4194,6 +4190,8 @@ spec:
                                   type: array
                               type: object
                           required:
+                          - certificateExpiry
+                          - renewBefore
                           - selector
                           type: object
                         children:
@@ -7814,14 +7812,12 @@ spec:
                                 that a user creates on a chaos experiment about pods.
                               properties:
                                 certificateExpiry:
-                                  default: 1h
                                   description: CertificateExpiry represents the expiry
                                     period for the requested certificate. Valid time
                                     units are "ns", "us" (or "µs"), "ms", "s", "m",
                                     "h".
                                   type: string
                                 duration:
-                                  default: 90m
                                   description: Duration represents the duration of
                                     the chaos action. Valid time units are "ns", "us"
                                     (or "µs"), "ms", "s", "m", "h".
@@ -7831,7 +7827,6 @@ spec:
                                     cluster where the chaos will be deployed
                                   type: string
                                 renewBefore:
-                                  default: 30m
                                   description: RenewBefore represents when the cert-manager
                                     should rotate the certificate. Valid time units
                                     are "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -7903,6 +7898,8 @@ spec:
                                       type: array
                                   type: object
                               required:
+                              - certificateExpiry
+                              - renewBefore
                               - selector
                               type: object
                             ciliumChaos:

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -289,13 +289,11 @@ spec:
                   creates on a chaos experiment about pods.
                 properties:
                   certificateExpiry:
-                    default: 1h
                     description: CertificateExpiry represents the expiry period for
                       the requested certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
                     type: string
                   duration:
-                    default: 90m
                     description: Duration represents the duration of the chaos action.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     type: string
@@ -304,7 +302,6 @@ spec:
                       the chaos will be deployed
                     type: string
                   renewBefore:
-                    default: 30m
                     description: RenewBefore represents when the cert-manager should
                       rotate the certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
@@ -369,6 +366,8 @@ spec:
                         type: array
                     type: object
                 required:
+                - certificateExpiry
+                - renewBefore
                 - selector
                 type: object
               children:
@@ -3757,13 +3756,11 @@ spec:
                       a user creates on a chaos experiment about pods.
                     properties:
                       certificateExpiry:
-                        default: 1h
                         description: CertificateExpiry represents the expiry period
                           for the requested certificate. Valid time units are "ns",
                           "us" (or "µs"), "ms", "s", "m", "h".
                         type: string
                       duration:
-                        default: 90m
                         description: Duration represents the duration of the chaos
                           action. Valid time units are "ns", "us" (or "µs"), "ms",
                           "s", "m", "h".
@@ -3773,7 +3770,6 @@ spec:
                           the chaos will be deployed
                         type: string
                       renewBefore:
-                        default: 30m
                         description: RenewBefore represents when the cert-manager
                           should rotate the certificate. Valid time units are "ns",
                           "us" (or "µs"), "ms", "s", "m", "h".
@@ -3839,6 +3835,8 @@ spec:
                             type: array
                         type: object
                     required:
+                    - certificateExpiry
+                    - renewBefore
                     - selector
                     type: object
                   ciliumChaos:
@@ -7670,14 +7668,12 @@ spec:
                                 that a user creates on a chaos experiment about pods.
                               properties:
                                 certificateExpiry:
-                                  default: 1h
                                   description: CertificateExpiry represents the expiry
                                     period for the requested certificate. Valid time
                                     units are "ns", "us" (or "µs"), "ms", "s", "m",
                                     "h".
                                   type: string
                                 duration:
-                                  default: 90m
                                   description: Duration represents the duration of
                                     the chaos action. Valid time units are "ns", "us"
                                     (or "µs"), "ms", "s", "m", "h".
@@ -7687,7 +7683,6 @@ spec:
                                     cluster where the chaos will be deployed
                                   type: string
                                 renewBefore:
-                                  default: 30m
                                   description: RenewBefore represents when the cert-manager
                                     should rotate the certificate. Valid time units
                                     are "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -7759,6 +7754,8 @@ spec:
                                       type: array
                                   type: object
                               required:
+                              - certificateExpiry
+                              - renewBefore
                               - selector
                               type: object
                             children:
@@ -11490,14 +11487,12 @@ spec:
                                     pods.
                                   properties:
                                     certificateExpiry:
-                                      default: 1h
                                       description: CertificateExpiry represents the
                                         expiry period for the requested certificate.
                                         Valid time units are "ns", "us" (or "µs"),
                                         "ms", "s", "m", "h".
                                       type: string
                                     duration:
-                                      default: 90m
                                       description: Duration represents the duration
                                         of the chaos action. Valid time units are
                                         "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -11507,7 +11502,6 @@ spec:
                                         cluster where the chaos will be deployed
                                       type: string
                                     renewBefore:
-                                      default: 30m
                                       description: RenewBefore represents when the
                                         cert-manager should rotate the certificate.
                                         Valid time units are "ns", "us" (or "µs"),
@@ -11582,6 +11576,8 @@ spec:
                                           type: array
                                       type: object
                                   required:
+                                  - certificateExpiry
+                                  - renewBefore
                                   - selector
                                   type: object
                                 ciliumChaos:

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -302,13 +302,11 @@ spec:
                         a user creates on a chaos experiment about pods.
                       properties:
                         certificateExpiry:
-                          default: 1h
                           description: CertificateExpiry represents the expiry period
                             for the requested certificate. Valid time units are "ns",
                             "us" (or "µs"), "ms", "s", "m", "h".
                           type: string
                         duration:
-                          default: 90m
                           description: Duration represents the duration of the chaos
                             action. Valid time units are "ns", "us" (or "µs"), "ms",
                             "s", "m", "h".
@@ -318,7 +316,6 @@ spec:
                             where the chaos will be deployed
                           type: string
                         renewBefore:
-                          default: 30m
                           description: RenewBefore represents when the cert-manager
                             should rotate the certificate. Valid time units are "ns",
                             "us" (or "µs"), "ms", "s", "m", "h".
@@ -384,6 +381,8 @@ spec:
                               type: array
                           type: object
                       required:
+                      - certificateExpiry
+                      - renewBefore
                       - selector
                       type: object
                     children:
@@ -3902,13 +3901,11 @@ spec:
                             that a user creates on a chaos experiment about pods.
                           properties:
                             certificateExpiry:
-                              default: 1h
                               description: CertificateExpiry represents the expiry
                                 period for the requested certificate. Valid time units
                                 are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                               type: string
                             duration:
-                              default: 90m
                               description: Duration represents the duration of the
                                 chaos action. Valid time units are "ns", "us" (or
                                 "µs"), "ms", "s", "m", "h".
@@ -3918,7 +3915,6 @@ spec:
                                 where the chaos will be deployed
                               type: string
                             renewBefore:
-                              default: 30m
                               description: RenewBefore represents when the cert-manager
                                 should rotate the certificate. Valid time units are
                                 "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -3987,6 +3983,8 @@ spec:
                                   type: array
                               type: object
                           required:
+                          - certificateExpiry
+                          - renewBefore
                           - selector
                           type: object
                         ciliumChaos:

--- a/controllers/chaosimpl/certificatechaos/impl.go
+++ b/controllers/chaosimpl/certificatechaos/impl.go
@@ -97,7 +97,7 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		return FluxSuspended, nil
 
 	case FluxSuspended:
-		var cert *cmv1.Certificate
+		cert := &cmv1.Certificate{}
 		err = impl.Get(ctx, namespacedName, cert)
 		if err != nil {
 			if apiErrors.IsNotFound(err) {

--- a/controllers/chaosimpl/certificatechaos/impl.go
+++ b/controllers/chaosimpl/certificatechaos/impl.go
@@ -97,8 +97,8 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		return FluxSuspended, nil
 
 	case FluxSuspended:
-		var cert cmv1.Certificate
-		err = impl.Get(ctx, namespacedName, &cert)
+		var cert *cmv1.Certificate
+		err = impl.Get(ctx, namespacedName, cert)
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
 				return v1alpha1.Injected, nil
@@ -106,17 +106,24 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 			return v1alpha1.NotInjected, err
 		}
 
-		// Update actual certificate
-		if err = impl.updateCertificate(ctx, &cert, chaos.Spec.CertificateExpiry, chaos.Spec.RenewBefore); err != nil {
-			impl.Log.Error(err, "Updating Certificate", "resource", cert.Name)
-			return record.Phase, err
+		var phase v1alpha1.Phase
+		// Check for changes - in case of exact match, there is no need to update
+		if certificateChanged(cert, chaos) {
+			// Update actual certificate
+			if err = impl.updateCertificate(ctx, cert, chaos.Spec.CertificateExpiry, chaos.Spec.RenewBefore); err != nil {
+				impl.Log.Error(err, "Updating Certificate", "resource", cert.Name)
+				return record.Phase, err
+			}
+			phase = CertUpdated
+		} else {
+			phase = CertReady
 		}
 		newInstance := chaos.Status.Instances[record.Id]
 		newInstance.OriginalExpiry = cert.Spec.Duration
 		newInstance.OriginalRenewBefore = cert.Spec.RenewBefore
 		newInstance.SecretName = cert.Spec.SecretName
 		chaos.Status.Instances[record.Id] = newInstance
-		return CertUpdated, nil
+		return phase, nil
 
 	case CertUpdated:
 		impl.Log.Info("Checking if Certificate is ready", "certificate", namespacedName.String())
@@ -161,6 +168,10 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 	}
 
 	return v1alpha1.Injected, nil
+}
+
+func certificateChanged(cert *cmv1.Certificate, chaos *v1alpha1.CertificateChaos) bool {
+	return !(cert.Spec.Duration == chaos.Spec.CertificateExpiry && cert.Spec.RenewBefore == chaos.Spec.RenewBefore)
 }
 
 func (impl *Impl) getPodOwnersUsingSecret(ctx context.Context, podsList *v1.PodList, secretName string) (map[Dependent]bool, error) {

--- a/helm/chaos-mesh/crds/chaos-mesh.org_certificatechaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_certificatechaos.yaml
@@ -35,13 +35,11 @@ spec:
             description: Spec defines the behavior of a certificate chaos experiment
             properties:
               certificateExpiry:
-                default: 1h
                 description: CertificateExpiry represents the expiry period for the
                   requested certificate. Valid time units are "ns", "us" (or "µs"),
                   "ms", "s", "m", "h".
                 type: string
               duration:
-                default: 90m
                 description: Duration represents the duration of the chaos action.
                   Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                 type: string
@@ -50,7 +48,6 @@ spec:
                   chaos will be deployed
                 type: string
               renewBefore:
-                default: 30m
                 description: RenewBefore represents when the cert-manager should rotate
                   the certificate. Valid time units are "ns", "us" (or "µs"), "ms",
                   "s", "m", "h".
@@ -115,6 +112,8 @@ spec:
                     type: array
                 type: object
             required:
+            - certificateExpiry
+            - renewBefore
             - selector
             type: object
           status:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -283,13 +283,11 @@ spec:
                   creates on a chaos experiment about pods.
                 properties:
                   certificateExpiry:
-                    default: 1h
                     description: CertificateExpiry represents the expiry period for
                       the requested certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
                     type: string
                   duration:
-                    default: 90m
                     description: Duration represents the duration of the chaos action.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     type: string
@@ -298,7 +296,6 @@ spec:
                       the chaos will be deployed
                     type: string
                   renewBefore:
-                    default: 30m
                     description: RenewBefore represents when the cert-manager should
                       rotate the certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
@@ -363,6 +360,8 @@ spec:
                         type: array
                     type: object
                 required:
+                - certificateExpiry
+                - renewBefore
                 - selector
                 type: object
               ciliumChaos:
@@ -4109,13 +4108,11 @@ spec:
                             that a user creates on a chaos experiment about pods.
                           properties:
                             certificateExpiry:
-                              default: 1h
                               description: CertificateExpiry represents the expiry
                                 period for the requested certificate. Valid time units
                                 are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                               type: string
                             duration:
-                              default: 90m
                               description: Duration represents the duration of the
                                 chaos action. Valid time units are "ns", "us" (or
                                 "µs"), "ms", "s", "m", "h".
@@ -4125,7 +4122,6 @@ spec:
                                 where the chaos will be deployed
                               type: string
                             renewBefore:
-                              default: 30m
                               description: RenewBefore represents when the cert-manager
                                 should rotate the certificate. Valid time units are
                                 "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -4194,6 +4190,8 @@ spec:
                                   type: array
                               type: object
                           required:
+                          - certificateExpiry
+                          - renewBefore
                           - selector
                           type: object
                         children:
@@ -7814,14 +7812,12 @@ spec:
                                 that a user creates on a chaos experiment about pods.
                               properties:
                                 certificateExpiry:
-                                  default: 1h
                                   description: CertificateExpiry represents the expiry
                                     period for the requested certificate. Valid time
                                     units are "ns", "us" (or "µs"), "ms", "s", "m",
                                     "h".
                                   type: string
                                 duration:
-                                  default: 90m
                                   description: Duration represents the duration of
                                     the chaos action. Valid time units are "ns", "us"
                                     (or "µs"), "ms", "s", "m", "h".
@@ -7831,7 +7827,6 @@ spec:
                                     cluster where the chaos will be deployed
                                   type: string
                                 renewBefore:
-                                  default: 30m
                                   description: RenewBefore represents when the cert-manager
                                     should rotate the certificate. Valid time units
                                     are "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -7903,6 +7898,8 @@ spec:
                                       type: array
                                   type: object
                               required:
+                              - certificateExpiry
+                              - renewBefore
                               - selector
                               type: object
                             ciliumChaos:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -289,13 +289,11 @@ spec:
                   creates on a chaos experiment about pods.
                 properties:
                   certificateExpiry:
-                    default: 1h
                     description: CertificateExpiry represents the expiry period for
                       the requested certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
                     type: string
                   duration:
-                    default: 90m
                     description: Duration represents the duration of the chaos action.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     type: string
@@ -304,7 +302,6 @@ spec:
                       the chaos will be deployed
                     type: string
                   renewBefore:
-                    default: 30m
                     description: RenewBefore represents when the cert-manager should
                       rotate the certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
@@ -369,6 +366,8 @@ spec:
                         type: array
                     type: object
                 required:
+                - certificateExpiry
+                - renewBefore
                 - selector
                 type: object
               children:
@@ -3757,13 +3756,11 @@ spec:
                       a user creates on a chaos experiment about pods.
                     properties:
                       certificateExpiry:
-                        default: 1h
                         description: CertificateExpiry represents the expiry period
                           for the requested certificate. Valid time units are "ns",
                           "us" (or "µs"), "ms", "s", "m", "h".
                         type: string
                       duration:
-                        default: 90m
                         description: Duration represents the duration of the chaos
                           action. Valid time units are "ns", "us" (or "µs"), "ms",
                           "s", "m", "h".
@@ -3773,7 +3770,6 @@ spec:
                           the chaos will be deployed
                         type: string
                       renewBefore:
-                        default: 30m
                         description: RenewBefore represents when the cert-manager
                           should rotate the certificate. Valid time units are "ns",
                           "us" (or "µs"), "ms", "s", "m", "h".
@@ -3839,6 +3835,8 @@ spec:
                             type: array
                         type: object
                     required:
+                    - certificateExpiry
+                    - renewBefore
                     - selector
                     type: object
                   ciliumChaos:
@@ -7670,14 +7668,12 @@ spec:
                                 that a user creates on a chaos experiment about pods.
                               properties:
                                 certificateExpiry:
-                                  default: 1h
                                   description: CertificateExpiry represents the expiry
                                     period for the requested certificate. Valid time
                                     units are "ns", "us" (or "µs"), "ms", "s", "m",
                                     "h".
                                   type: string
                                 duration:
-                                  default: 90m
                                   description: Duration represents the duration of
                                     the chaos action. Valid time units are "ns", "us"
                                     (or "µs"), "ms", "s", "m", "h".
@@ -7687,7 +7683,6 @@ spec:
                                     cluster where the chaos will be deployed
                                   type: string
                                 renewBefore:
-                                  default: 30m
                                   description: RenewBefore represents when the cert-manager
                                     should rotate the certificate. Valid time units
                                     are "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -7759,6 +7754,8 @@ spec:
                                       type: array
                                   type: object
                               required:
+                              - certificateExpiry
+                              - renewBefore
                               - selector
                               type: object
                             children:
@@ -11490,14 +11487,12 @@ spec:
                                     pods.
                                   properties:
                                     certificateExpiry:
-                                      default: 1h
                                       description: CertificateExpiry represents the
                                         expiry period for the requested certificate.
                                         Valid time units are "ns", "us" (or "µs"),
                                         "ms", "s", "m", "h".
                                       type: string
                                     duration:
-                                      default: 90m
                                       description: Duration represents the duration
                                         of the chaos action. Valid time units are
                                         "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -11507,7 +11502,6 @@ spec:
                                         cluster where the chaos will be deployed
                                       type: string
                                     renewBefore:
-                                      default: 30m
                                       description: RenewBefore represents when the
                                         cert-manager should rotate the certificate.
                                         Valid time units are "ns", "us" (or "µs"),
@@ -11582,6 +11576,8 @@ spec:
                                           type: array
                                       type: object
                                   required:
+                                  - certificateExpiry
+                                  - renewBefore
                                   - selector
                                   type: object
                                 ciliumChaos:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -302,13 +302,11 @@ spec:
                         a user creates on a chaos experiment about pods.
                       properties:
                         certificateExpiry:
-                          default: 1h
                           description: CertificateExpiry represents the expiry period
                             for the requested certificate. Valid time units are "ns",
                             "us" (or "µs"), "ms", "s", "m", "h".
                           type: string
                         duration:
-                          default: 90m
                           description: Duration represents the duration of the chaos
                             action. Valid time units are "ns", "us" (or "µs"), "ms",
                             "s", "m", "h".
@@ -318,7 +316,6 @@ spec:
                             where the chaos will be deployed
                           type: string
                         renewBefore:
-                          default: 30m
                           description: RenewBefore represents when the cert-manager
                             should rotate the certificate. Valid time units are "ns",
                             "us" (or "µs"), "ms", "s", "m", "h".
@@ -384,6 +381,8 @@ spec:
                               type: array
                           type: object
                       required:
+                      - certificateExpiry
+                      - renewBefore
                       - selector
                       type: object
                     children:
@@ -3902,13 +3901,11 @@ spec:
                             that a user creates on a chaos experiment about pods.
                           properties:
                             certificateExpiry:
-                              default: 1h
                               description: CertificateExpiry represents the expiry
                                 period for the requested certificate. Valid time units
                                 are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                               type: string
                             duration:
-                              default: 90m
                               description: Duration represents the duration of the
                                 chaos action. Valid time units are "ns", "us" (or
                                 "µs"), "ms", "s", "m", "h".
@@ -3918,7 +3915,6 @@ spec:
                                 where the chaos will be deployed
                               type: string
                             renewBefore:
-                              default: 30m
                               description: RenewBefore represents when the cert-manager
                                 should rotate the certificate. Valid time units are
                                 "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -3987,6 +3983,8 @@ spec:
                                   type: array
                               type: object
                           required:
+                          - certificateExpiry
+                          - renewBefore
                           - selector
                           type: object
                         ciliumChaos:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -669,13 +669,11 @@ spec:
             description: Spec defines the behavior of a certificate chaos experiment
             properties:
               certificateExpiry:
-                default: 1h
                 description: CertificateExpiry represents the expiry period for the
                   requested certificate. Valid time units are "ns", "us" (or "µs"),
                   "ms", "s", "m", "h".
                 type: string
               duration:
-                default: 90m
                 description: Duration represents the duration of the chaos action.
                   Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                 type: string
@@ -684,7 +682,6 @@ spec:
                   chaos will be deployed
                 type: string
               renewBefore:
-                default: 30m
                 description: RenewBefore represents when the cert-manager should rotate
                   the certificate. Valid time units are "ns", "us" (or "µs"), "ms",
                   "s", "m", "h".
@@ -749,6 +746,8 @@ spec:
                     type: array
                 type: object
             required:
+            - certificateExpiry
+            - renewBefore
             - selector
             type: object
           status:
@@ -7006,13 +7005,11 @@ spec:
                   creates on a chaos experiment about pods.
                 properties:
                   certificateExpiry:
-                    default: 1h
                     description: CertificateExpiry represents the expiry period for
                       the requested certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
                     type: string
                   duration:
-                    default: 90m
                     description: Duration represents the duration of the chaos action.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     type: string
@@ -7021,7 +7018,6 @@ spec:
                       the chaos will be deployed
                     type: string
                   renewBefore:
-                    default: 30m
                     description: RenewBefore represents when the cert-manager should
                       rotate the certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
@@ -7086,6 +7082,8 @@ spec:
                         type: array
                     type: object
                 required:
+                - certificateExpiry
+                - renewBefore
                 - selector
                 type: object
               ciliumChaos:
@@ -10832,13 +10830,11 @@ spec:
                             that a user creates on a chaos experiment about pods.
                           properties:
                             certificateExpiry:
-                              default: 1h
                               description: CertificateExpiry represents the expiry
                                 period for the requested certificate. Valid time units
                                 are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                               type: string
                             duration:
-                              default: 90m
                               description: Duration represents the duration of the
                                 chaos action. Valid time units are "ns", "us" (or
                                 "µs"), "ms", "s", "m", "h".
@@ -10848,7 +10844,6 @@ spec:
                                 where the chaos will be deployed
                               type: string
                             renewBefore:
-                              default: 30m
                               description: RenewBefore represents when the cert-manager
                                 should rotate the certificate. Valid time units are
                                 "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -10917,6 +10912,8 @@ spec:
                                   type: array
                               type: object
                           required:
+                          - certificateExpiry
+                          - renewBefore
                           - selector
                           type: object
                         children:
@@ -14537,14 +14534,12 @@ spec:
                                 that a user creates on a chaos experiment about pods.
                               properties:
                                 certificateExpiry:
-                                  default: 1h
                                   description: CertificateExpiry represents the expiry
                                     period for the requested certificate. Valid time
                                     units are "ns", "us" (or "µs"), "ms", "s", "m",
                                     "h".
                                   type: string
                                 duration:
-                                  default: 90m
                                   description: Duration represents the duration of
                                     the chaos action. Valid time units are "ns", "us"
                                     (or "µs"), "ms", "s", "m", "h".
@@ -14554,7 +14549,6 @@ spec:
                                     cluster where the chaos will be deployed
                                   type: string
                                 renewBefore:
-                                  default: 30m
                                   description: RenewBefore represents when the cert-manager
                                     should rotate the certificate. Valid time units
                                     are "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -14626,6 +14620,8 @@ spec:
                                       type: array
                                   type: object
                               required:
+                              - certificateExpiry
+                              - renewBefore
                               - selector
                               type: object
                             ciliumChaos:
@@ -24831,13 +24827,11 @@ spec:
                   creates on a chaos experiment about pods.
                 properties:
                   certificateExpiry:
-                    default: 1h
                     description: CertificateExpiry represents the expiry period for
                       the requested certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
                     type: string
                   duration:
-                    default: 90m
                     description: Duration represents the duration of the chaos action.
                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     type: string
@@ -24846,7 +24840,6 @@ spec:
                       the chaos will be deployed
                     type: string
                   renewBefore:
-                    default: 30m
                     description: RenewBefore represents when the cert-manager should
                       rotate the certificate. Valid time units are "ns", "us" (or
                       "µs"), "ms", "s", "m", "h".
@@ -24911,6 +24904,8 @@ spec:
                         type: array
                     type: object
                 required:
+                - certificateExpiry
+                - renewBefore
                 - selector
                 type: object
               children:
@@ -28299,13 +28294,11 @@ spec:
                       a user creates on a chaos experiment about pods.
                     properties:
                       certificateExpiry:
-                        default: 1h
                         description: CertificateExpiry represents the expiry period
                           for the requested certificate. Valid time units are "ns",
                           "us" (or "µs"), "ms", "s", "m", "h".
                         type: string
                       duration:
-                        default: 90m
                         description: Duration represents the duration of the chaos
                           action. Valid time units are "ns", "us" (or "µs"), "ms",
                           "s", "m", "h".
@@ -28315,7 +28308,6 @@ spec:
                           the chaos will be deployed
                         type: string
                       renewBefore:
-                        default: 30m
                         description: RenewBefore represents when the cert-manager
                           should rotate the certificate. Valid time units are "ns",
                           "us" (or "µs"), "ms", "s", "m", "h".
@@ -28381,6 +28373,8 @@ spec:
                             type: array
                         type: object
                     required:
+                    - certificateExpiry
+                    - renewBefore
                     - selector
                     type: object
                   ciliumChaos:
@@ -32212,14 +32206,12 @@ spec:
                                 that a user creates on a chaos experiment about pods.
                               properties:
                                 certificateExpiry:
-                                  default: 1h
                                   description: CertificateExpiry represents the expiry
                                     period for the requested certificate. Valid time
                                     units are "ns", "us" (or "µs"), "ms", "s", "m",
                                     "h".
                                   type: string
                                 duration:
-                                  default: 90m
                                   description: Duration represents the duration of
                                     the chaos action. Valid time units are "ns", "us"
                                     (or "µs"), "ms", "s", "m", "h".
@@ -32229,7 +32221,6 @@ spec:
                                     cluster where the chaos will be deployed
                                   type: string
                                 renewBefore:
-                                  default: 30m
                                   description: RenewBefore represents when the cert-manager
                                     should rotate the certificate. Valid time units
                                     are "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -32301,6 +32292,8 @@ spec:
                                       type: array
                                   type: object
                               required:
+                              - certificateExpiry
+                              - renewBefore
                               - selector
                               type: object
                             children:
@@ -36032,14 +36025,12 @@ spec:
                                     pods.
                                   properties:
                                     certificateExpiry:
-                                      default: 1h
                                       description: CertificateExpiry represents the
                                         expiry period for the requested certificate.
                                         Valid time units are "ns", "us" (or "µs"),
                                         "ms", "s", "m", "h".
                                       type: string
                                     duration:
-                                      default: 90m
                                       description: Duration represents the duration
                                         of the chaos action. Valid time units are
                                         "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -36049,7 +36040,6 @@ spec:
                                         cluster where the chaos will be deployed
                                       type: string
                                     renewBefore:
-                                      default: 30m
                                       description: RenewBefore represents when the
                                         cert-manager should rotate the certificate.
                                         Valid time units are "ns", "us" (or "µs"),
@@ -36124,6 +36114,8 @@ spec:
                                           type: array
                                       type: object
                                   required:
+                                  - certificateExpiry
+                                  - renewBefore
                                   - selector
                                   type: object
                                 ciliumChaos:
@@ -50697,13 +50689,11 @@ spec:
                         a user creates on a chaos experiment about pods.
                       properties:
                         certificateExpiry:
-                          default: 1h
                           description: CertificateExpiry represents the expiry period
                             for the requested certificate. Valid time units are "ns",
                             "us" (or "µs"), "ms", "s", "m", "h".
                           type: string
                         duration:
-                          default: 90m
                           description: Duration represents the duration of the chaos
                             action. Valid time units are "ns", "us" (or "µs"), "ms",
                             "s", "m", "h".
@@ -50713,7 +50703,6 @@ spec:
                             where the chaos will be deployed
                           type: string
                         renewBefore:
-                          default: 30m
                           description: RenewBefore represents when the cert-manager
                             should rotate the certificate. Valid time units are "ns",
                             "us" (or "µs"), "ms", "s", "m", "h".
@@ -50779,6 +50768,8 @@ spec:
                               type: array
                           type: object
                       required:
+                      - certificateExpiry
+                      - renewBefore
                       - selector
                       type: object
                     children:
@@ -54297,13 +54288,11 @@ spec:
                             that a user creates on a chaos experiment about pods.
                           properties:
                             certificateExpiry:
-                              default: 1h
                               description: CertificateExpiry represents the expiry
                                 period for the requested certificate. Valid time units
                                 are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                               type: string
                             duration:
-                              default: 90m
                               description: Duration represents the duration of the
                                 chaos action. Valid time units are "ns", "us" (or
                                 "µs"), "ms", "s", "m", "h".
@@ -54313,7 +54302,6 @@ spec:
                                 where the chaos will be deployed
                               type: string
                             renewBefore:
-                              default: 30m
                               description: RenewBefore represents when the cert-manager
                                 should rotate the certificate. Valid time units are
                                 "ns", "us" (or "µs"), "ms", "s", "m", "h".
@@ -54382,6 +54370,8 @@ spec:
                                   type: array
                               type: object
                           required:
+                          - certificateExpiry
+                          - renewBefore
                           - selector
                           type: object
                         ciliumChaos:

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -5446,7 +5446,7 @@ const docTemplate = `{
                     }
                 },
                 "certificateExpiry": {
-                    "description": "CertificateExpiry represents the expiry period for the requested certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n",
+                    "description": "CertificateExpiry represents the expiry period for the requested certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".",
                     "$ref": "#/definitions/v1.Duration"
                 },
                 "duration": {

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -5446,11 +5446,11 @@ const docTemplate = `{
                     }
                 },
                 "certificateExpiry": {
-                    "description": "CertificateExpiry represents the expiry period for the requested certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional\n+kubebuilder:default=\"1h\"",
+                    "description": "CertificateExpiry represents the expiry period for the requested certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n",
                     "$ref": "#/definitions/v1.Duration"
                 },
                 "duration": {
-                    "description": "Duration represents the duration of the chaos action.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional\n+kubebuilder:default=\"90m\"",
+                    "description": "Duration represents the duration of the chaos action.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional",
                     "type": "string"
                 },
                 "fieldSelectors": {
@@ -5479,7 +5479,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "renewBefore": {
-                    "description": "RenewBefore represents when the cert-manager should rotate the certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional\n+kubebuilder:default=\"30m\"",
+                    "description": "RenewBefore represents when the cert-manager should rotate the certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".",
                     "$ref": "#/definitions/v1.Duration"
                 }
             }

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -5438,11 +5438,11 @@
                     }
                 },
                 "certificateExpiry": {
-                    "description": "CertificateExpiry represents the expiry period for the requested certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional\n+kubebuilder:default=\"1h\"",
+                    "description": "CertificateExpiry represents the expiry period for the requested certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".",
                     "$ref": "#/definitions/v1.Duration"
                 },
                 "duration": {
-                    "description": "Duration represents the duration of the chaos action.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional\n+kubebuilder:default=\"90m\"",
+                    "description": "Duration represents the duration of the chaos action.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional",
                     "type": "string"
                 },
                 "fieldSelectors": {
@@ -5471,7 +5471,7 @@
                     "type": "string"
                 },
                 "renewBefore": {
-                    "description": "RenewBefore represents when the cert-manager should rotate the certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n+optional\n+kubebuilder:default=\"30m\"",
+                    "description": "RenewBefore represents when the cert-manager should rotate the certificate.\nValid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".",
                     "$ref": "#/definitions/v1.Duration"
                 }
             }

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -3894,14 +3894,11 @@ definitions:
         description: |-
           CertificateExpiry represents the expiry period for the requested certificate.
           Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-          +optional
-          +kubebuilder:default="1h"
       duration:
         description: |-
           Duration represents the duration of the chaos action.
           Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
           +optional
-          +kubebuilder:default="90m"
         type: string
       fieldSelectors:
         additionalProperties:
@@ -3936,8 +3933,6 @@ definitions:
         description: |-
           RenewBefore represents when the cert-manager should rotate the certificate.
           Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-          +optional
-          +kubebuilder:default="30m"
     type: object
   v1alpha1.ChaosOnlyScheduleSpec:
     properties:


### PR DESCRIPTION
Avoid endless loop for unchanged cert.  If the certificate details have not changed, skip the ready check.

Additionally, make the `CertificateExpiry` and `RenewBefore` fields required, not optional, and remove default values.