### PR TITLE
chore: Add flag to create or disable chaos daemon

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+{{- if .Values.chaosDaemon.create }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -213,3 +214,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 {{- if .Values.chaosDaemon.create }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+{{- if .Values.chaosDaemon.create }}
 {{- if .Values.chaosDaemon.serviceAccount }}
 ---
 kind: ServiceAccount
@@ -131,5 +132,6 @@ spec:
   - projected
   - secret
   - hostPath
+{{- end }}
 {{- end }}
 

--- a/helm/chaos-mesh/templates/chaos-daemon-service.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-service.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+{{- if .Values.chaosDaemon.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -43,3 +44,4 @@ spec:
   selector:
     {{- include "chaos-mesh.selectors" . | nindent 4 }}
     app.kubernetes.io/component: chaos-daemon
+{{- end }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -180,6 +180,8 @@ controllerManager:
         type: DirectoryOrCreate
 
 chaosDaemon:
+  # Enable chaos-daemon
+  create: true
   # image would be constructed by <registry>/<repository>:<tag>
   image:
     # override global registry, empty value means using the global images.registry

--- a/install.sh
+++ b/install.sh
@@ -1622,7 +1622,6 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
Adds a flag in values file, to make deploying the chaos-damon component optional

```
chaosDaemon:
  create: true
```

## Proof of Work

Local test using Tilt, setting flags in Tiltfile:

![image](https://github.com/user-attachments/assets/73aff4d7-08ac-40c3-9c42-b50d048e3b8e)

### Before
![image](https://github.com/user-attachments/assets/109d51fe-8593-4fde-b27e-4dbd7449cbf0)

### After
![image](https://github.com/user-attachments/assets/217e3f40-7df3-4f77-9826-96c3c7193d21)

Depends On:
- https://github.com/form3tech-oss/chaos-mesh/pull/89