### PR TITLE
chore: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build_targets.yaml
+++ b/.github/workflows/build_targets.yaml
@@ -100,7 +100,7 @@ jobs:
           key: ${{ inputs.images-cache-key }}
 
       - name: Upload saved images
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.images-artifact-name }}
           path: ./output/saved-images
@@ -134,7 +134,7 @@ jobs:
           key: ${{ inputs.e2e-binary-cache-key }}
 
       - name: Upload e2e binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.e2e-binary-name }}
           path: ./e2e-test/image/e2e/bin
@@ -169,7 +169,7 @@ jobs:
           echo "chart-name=$chart_name" >> $GITHUB_OUTPUT
 
       - name: Upload chart
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.chart-artifact-name }}
           path: ${{ steps.build-chart.outputs.chart-path }}


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
