### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
   release:
     runs-on: ubuntu-20.04
-    needs: [calculate-tag, build-targets]
+    needs: [calculate-tag, build-targets, e2e-test, integration-test]
     permissions: write-all
     steps:
       - name: Download saved images


### PR DESCRIPTION
Changing CI workflow so that `release` is the final step, and waits for `e2e-tests` and `integration-tests` to complete.

This will then be the only required check for merging PR, as defined in `infrastructure-github`

- https://github.com/form3tech/infrastructure-github/pull/7874