### PR TITLE
fix: Add a common check to use as a required check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,41 @@ jobs:
     with:
       images-artifact-name: ${{ needs.build-targets.outputs.images-artifact-name }}
 
+  pass:
+    if: always()
+    needs:
+      - changed-files
+      - unit-test
+      - integration-test
+      - e2e-test
+    name: All Checks Pass
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          result="${{ needs.changed-files.result }}"
+          if [[ ! $result == "success" ]]; then
+            echo "changed-files has failed"
+            exit 1
+          fi
+
+          result="${{ needs.unit-test.result }}"
+          if [[ ! ($result == "success" || $result == "skipped") ]]; then
+            echo "unit-test has failed"
+            exit 1
+          fi
+
+          result="${{ needs.integration-test.result }}"
+          if [[ ! ($result == "success" || $result == "skipped") ]]; then
+            echo "integration-test has failed"
+            exit 1
+          fi
+
+          result="${{ needs.e2e-test.result }}"
+          if [[ ! ($result == "success" || $result == "skipped") ]]; then
+            echo "e2e-test has failed"
+            exit 1
+          fi
+
   release:
     runs-on: ubuntu-20.04
     needs: [calculate-tag, build-targets]


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

- Currently, with a large matrix job and several optional tests there are not good required checks for PRs as they can often be skipped.
- This PR allows setting a single required check that alongside a few other required checks ensures the tests either run when needed or are skipped when not and the PRs are correctly blocked in both cases if there is an issue with the checks.

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

- The single job will verify that required jobs have succeeded and the optional ones either succeeded or were skipped, which happens when their conditions are not fulfilled and is expected for some PRs.
- Adding a few other jobs to required checks means there shouldn't be a scenario where jobs that are supposed to run were skipped or failed and the PR is mergeable. 

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
