### PR TITLE
chore: Add tags to help debugging

### DIFF
--- a/pkg/selector/aws/selector.go
+++ b/pkg/selector/aws/selector.go
@@ -53,6 +53,9 @@ type Instance struct {
 	SecretName *string
 	EbsVolume  *string
 	DeviceName *string
+	// Tags is only used for debug information
+	// It is saved to the selector and logged in the id column
+	Tags map[string]string
 }
 
 func (instance *Instance) Id() string {
@@ -96,6 +99,7 @@ func (impl *SelectImpl) Select(ctx context.Context, awsSelector *v1alpha1.AWSSel
 			SecretName: awsSelector.SecretName,
 			EbsVolume:  awsSelector.EbsVolume,
 			DeviceName: awsSelector.DeviceName,
+			Tags:       readTags(r.Instances[0].Tags),
 		})
 	}
 	mode := awsSelector.Mode
@@ -107,6 +111,16 @@ func (impl *SelectImpl) Select(ctx context.Context, awsSelector *v1alpha1.AWSSel
 	}
 
 	return filteredInstances, nil
+}
+
+func readTags(sourceTags []ec2types.Tag) map[string]string {
+	tags := map[string]string{}
+	for _, tag := range sourceTags {
+		if tag.Key != nil && tag.Value != nil {
+			tags[*tag.Key] = *tag.Value
+		}
+	}
+	return tags
 }
 
 type Params struct {


### PR DESCRIPTION
When rebooting VMS during AZ Loss experiment, it is difficult to correlate logs with actual instances.

InstanceIDs are not long lived, so can change after a rollout making it difficult to verify what happened.

Since there is no obvious name or description field in the instance, I'm adding Tags field which usually contains a name and other useful metadata.

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
