### PR TITLE
fix: Fix recover step for NodeSelectorChaos

### DIFF
--- a/api/v1alpha1/nodeselectorchaos_types.go
+++ b/api/v1alpha1/nodeselectorchaos_types.go
@@ -38,7 +38,8 @@ type NodeSelectorChaosSpec struct {
 	DeploymentSelectorSpec `json:"selector"`
 	// Key is the name of the key that will be applied to the deployment's nodeSelector field.
 	Key string `json:"key"`
-	// Value is the value assigned to the provided key.
+	// Value is the value assigned to the provided key. If empty, the key will be removed.
+	// +optional
 	Value string `json:"value"`
 	// Duration represents the duration of the chaos
 	// +optional

--- a/config/crd/bases/chaos-mesh.org_nodeselectorchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_nodeselectorchaos.yaml
@@ -55,12 +55,12 @@ spec:
                     type: object
                 type: object
               value:
-                description: Value is the value assigned to the provided key.
+                description: Value is the value assigned to the provided key. If empty,
+                  the key will be removed.
                 type: string
             required:
             - key
             - selector
-            - value
             type: object
           status:
             properties:

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -2299,11 +2299,11 @@ spec:
                     type: object
                   value:
                     description: Value is the value assigned to the provided key.
+                      If empty, the key will be removed.
                     type: string
                 required:
                 - key
                 - selector
-                - value
                 type: object
               physicalmachineChaos:
                 description: PhysicalMachineChaosSpec defines the desired state of
@@ -6432,12 +6432,11 @@ spec:
                               type: object
                             value:
                               description: Value is the value assigned to the provided
-                                key.
+                                key. If empty, the key will be removed.
                               type: string
                           required:
                           - key
                           - selector
-                          - value
                           type: object
                         physicalmachineChaos:
                           description: PhysicalMachineChaosSpec defines the desired
@@ -10333,12 +10332,11 @@ spec:
                                   type: object
                                 value:
                                   description: Value is the value assigned to the
-                                    provided key.
+                                    provided key. If empty, the key will be removed.
                                   type: string
                               required:
                               - key
                               - selector
-                              - value
                               type: object
                             physicalmachineChaos:
                               description: PhysicalMachineChaosSpec defines the desired

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -2320,11 +2320,11 @@ spec:
                     type: object
                   value:
                     description: Value is the value assigned to the provided key.
+                      If empty, the key will be removed.
                     type: string
                 required:
                 - key
                 - selector
-                - value
                 type: object
               physicalmachineChaos:
                 description: PhysicalMachineChaosSpec defines the desired state of
@@ -5975,11 +5975,11 @@ spec:
                         type: object
                       value:
                         description: Value is the value assigned to the provided key.
+                          If empty, the key will be removed.
                         type: string
                     required:
                     - key
                     - selector
-                    - value
                     type: object
                   physicalmachineChaos:
                     description: PhysicalMachineChaosSpec defines the desired state
@@ -10207,12 +10207,11 @@ spec:
                                   type: object
                                 value:
                                   description: Value is the value assigned to the
-                                    provided key.
+                                    provided key. If empty, the key will be removed.
                                   type: string
                               required:
                               - key
                               - selector
-                              - value
                               type: object
                             physicalmachineChaos:
                               description: PhysicalMachineChaosSpec defines the desired
@@ -14238,12 +14237,12 @@ spec:
                                       type: object
                                     value:
                                       description: Value is the value assigned to
-                                        the provided key.
+                                        the provided key. If empty, the key will be
+                                        removed.
                                       type: string
                                   required:
                                   - key
                                   - selector
-                                  - value
                                   type: object
                                 physicalmachineChaos:
                                   description: PhysicalMachineChaosSpec defines the

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -2408,12 +2408,11 @@ spec:
                           type: object
                         value:
                           description: Value is the value assigned to the provided
-                            key.
+                            key. If empty, the key will be removed.
                           type: string
                       required:
                       - key
                       - selector
-                      - value
                       type: object
                     physicalmachineChaos:
                       description: PhysicalMachineChaosSpec defines the desired state
@@ -6206,12 +6205,11 @@ spec:
                               type: object
                             value:
                               description: Value is the value assigned to the provided
-                                key.
+                                key. If empty, the key will be removed.
                               type: string
                           required:
                           - key
                           - selector
-                          - value
                           type: object
                         physicalmachineChaos:
                           description: PhysicalMachineChaosSpec defines the desired

--- a/helm/chaos-mesh/crds/chaos-mesh.org_nodeselectorchaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_nodeselectorchaos.yaml
@@ -55,12 +55,12 @@ spec:
                     type: object
                 type: object
               value:
-                description: Value is the value assigned to the provided key.
+                description: Value is the value assigned to the provided key. If empty,
+                  the key will be removed.
                 type: string
             required:
             - key
             - selector
-            - value
             type: object
           status:
             properties:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -2299,11 +2299,11 @@ spec:
                     type: object
                   value:
                     description: Value is the value assigned to the provided key.
+                      If empty, the key will be removed.
                     type: string
                 required:
                 - key
                 - selector
-                - value
                 type: object
               physicalmachineChaos:
                 description: PhysicalMachineChaosSpec defines the desired state of
@@ -6432,12 +6432,11 @@ spec:
                               type: object
                             value:
                               description: Value is the value assigned to the provided
-                                key.
+                                key. If empty, the key will be removed.
                               type: string
                           required:
                           - key
                           - selector
-                          - value
                           type: object
                         physicalmachineChaos:
                           description: PhysicalMachineChaosSpec defines the desired
@@ -10333,12 +10332,11 @@ spec:
                                   type: object
                                 value:
                                   description: Value is the value assigned to the
-                                    provided key.
+                                    provided key. If empty, the key will be removed.
                                   type: string
                               required:
                               - key
                               - selector
-                              - value
                               type: object
                             physicalmachineChaos:
                               description: PhysicalMachineChaosSpec defines the desired

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -2320,11 +2320,11 @@ spec:
                     type: object
                   value:
                     description: Value is the value assigned to the provided key.
+                      If empty, the key will be removed.
                     type: string
                 required:
                 - key
                 - selector
-                - value
                 type: object
               physicalmachineChaos:
                 description: PhysicalMachineChaosSpec defines the desired state of
@@ -5975,11 +5975,11 @@ spec:
                         type: object
                       value:
                         description: Value is the value assigned to the provided key.
+                          If empty, the key will be removed.
                         type: string
                     required:
                     - key
                     - selector
-                    - value
                     type: object
                   physicalmachineChaos:
                     description: PhysicalMachineChaosSpec defines the desired state
@@ -10207,12 +10207,11 @@ spec:
                                   type: object
                                 value:
                                   description: Value is the value assigned to the
-                                    provided key.
+                                    provided key. If empty, the key will be removed.
                                   type: string
                               required:
                               - key
                               - selector
-                              - value
                               type: object
                             physicalmachineChaos:
                               description: PhysicalMachineChaosSpec defines the desired
@@ -14238,12 +14237,12 @@ spec:
                                       type: object
                                     value:
                                       description: Value is the value assigned to
-                                        the provided key.
+                                        the provided key. If empty, the key will be
+                                        removed.
                                       type: string
                                   required:
                                   - key
                                   - selector
-                                  - value
                                   type: object
                                 physicalmachineChaos:
                                   description: PhysicalMachineChaosSpec defines the

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -2408,12 +2408,11 @@ spec:
                           type: object
                         value:
                           description: Value is the value assigned to the provided
-                            key.
+                            key. If empty, the key will be removed.
                           type: string
                       required:
                       - key
                       - selector
-                      - value
                       type: object
                     physicalmachineChaos:
                       description: PhysicalMachineChaosSpec defines the desired state
@@ -6206,12 +6205,11 @@ spec:
                               type: object
                             value:
                               description: Value is the value assigned to the provided
-                                key.
+                                key. If empty, the key will be removed.
                               type: string
                           required:
                           - key
                           - selector
-                          - value
                           type: object
                         physicalmachineChaos:
                           description: PhysicalMachineChaosSpec defines the desired

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4257,12 +4257,12 @@ spec:
                     type: object
                 type: object
               value:
-                description: Value is the value assigned to the provided key.
+                description: Value is the value assigned to the provided key. If empty,
+                  the key will be removed.
                 type: string
             required:
             - key
             - selector
-            - value
             type: object
           status:
             properties:
@@ -9433,11 +9433,11 @@ spec:
                     type: object
                   value:
                     description: Value is the value assigned to the provided key.
+                      If empty, the key will be removed.
                     type: string
                 required:
                 - key
                 - selector
-                - value
                 type: object
               physicalmachineChaos:
                 description: PhysicalMachineChaosSpec defines the desired state of
@@ -13566,12 +13566,11 @@ spec:
                               type: object
                             value:
                               description: Value is the value assigned to the provided
-                                key.
+                                key. If empty, the key will be removed.
                               type: string
                           required:
                           - key
                           - selector
-                          - value
                           type: object
                         physicalmachineChaos:
                           description: PhysicalMachineChaosSpec defines the desired
@@ -17467,12 +17466,11 @@ spec:
                                   type: object
                                 value:
                                   description: Value is the value assigned to the
-                                    provided key.
+                                    provided key. If empty, the key will be removed.
                                   type: string
                               required:
                               - key
                               - selector
-                              - value
                               type: object
                             physicalmachineChaos:
                               description: PhysicalMachineChaosSpec defines the desired
@@ -27738,11 +27736,11 @@ spec:
                     type: object
                   value:
                     description: Value is the value assigned to the provided key.
+                      If empty, the key will be removed.
                     type: string
                 required:
                 - key
                 - selector
-                - value
                 type: object
               physicalmachineChaos:
                 description: PhysicalMachineChaosSpec defines the desired state of
@@ -31393,11 +31391,11 @@ spec:
                         type: object
                       value:
                         description: Value is the value assigned to the provided key.
+                          If empty, the key will be removed.
                         type: string
                     required:
                     - key
                     - selector
-                    - value
                     type: object
                   physicalmachineChaos:
                     description: PhysicalMachineChaosSpec defines the desired state
@@ -35625,12 +35623,11 @@ spec:
                                   type: object
                                 value:
                                   description: Value is the value assigned to the
-                                    provided key.
+                                    provided key. If empty, the key will be removed.
                                   type: string
                               required:
                               - key
                               - selector
-                              - value
                               type: object
                             physicalmachineChaos:
                               description: PhysicalMachineChaosSpec defines the desired
@@ -39656,12 +39653,12 @@ spec:
                                       type: object
                                     value:
                                       description: Value is the value assigned to
-                                        the provided key.
+                                        the provided key. If empty, the key will be
+                                        removed.
                                       type: string
                                   required:
                                   - key
                                   - selector
-                                  - value
                                   type: object
                                 physicalmachineChaos:
                                   description: PhysicalMachineChaosSpec defines the
@@ -54304,12 +54301,11 @@ spec:
                           type: object
                         value:
                           description: Value is the value assigned to the provided
-                            key.
+                            key. If empty, the key will be removed.
                           type: string
                       required:
                       - key
                       - selector
-                      - value
                       type: object
                     physicalmachineChaos:
                       description: PhysicalMachineChaosSpec defines the desired state
@@ -58102,12 +58098,11 @@ spec:
                               type: object
                             value:
                               description: Value is the value assigned to the provided
-                                key.
+                                key. If empty, the key will be removed.
                               type: string
                           required:
                           - key
                           - selector
-                          - value
                           type: object
                         physicalmachineChaos:
                           description: PhysicalMachineChaosSpec defines the desired

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -7302,7 +7302,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {
-                    "description": "Value is the value assigned to the provided key.",
+                    "description": "Value is the value assigned to the provided key. If empty, the key will be removed.\n+optional",
                     "type": "string"
                 }
             }

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -7294,7 +7294,7 @@
                     "type": "string"
                 },
                 "value": {
-                    "description": "Value is the value assigned to the provided key.",
+                    "description": "Value is the value assigned to the provided key. If empty, the key will be removed.\n+optional",
                     "type": "string"
                 }
             }

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -5762,7 +5762,9 @@ definitions:
           +optional
         type: string
       value:
-        description: Value is the value assigned to the provided key.
+        description: |-
+          Value is the value assigned to the provided key. If empty, the key will be removed.
+          +optional
         type: string
     type: object
   v1alpha1.NodeSelectorSpec:


### PR DESCRIPTION
## What problem does this PR solve?

Currently, the recovery step might remove the annotation too early. It will be a no-op and a cleanup step will be used instead. To this end, the value is now optional.

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

<details><summary>chaos.yml</summary>



    ---
    apiVersion: chaos-mesh.org/v1alpha1
    kind: Schedule
    metadata:
      name: az-loss
    spec:
      schedule: '0/5 * * * *' 
      historyLimit: 1
      concurrencyPolicy: 'Forbid'
      startingDeadlineSeconds: 1
      type: 'Workflow'
      workflow:
        entry: az-loss-workflow-entry
        templates:
          - name: az-loss-workflow-entry
            templateType: Serial
            deadline: 5m
            children:
              - eu-west-2a-az-chaos-20m
              - eu-west-2a-az-chaos-default
          - name: eu-west-2a-az-chaos-20m
            templateType: NodeSelectorChaos
            deadline: 3m
            nodeselectorChaos:
              value: eu-west-2a
              key: topology.kubernetes.io/zone
              selector:
                deployments:
                  nats-eks:
                    - nats-box
          - name: eu-west-2a-az-chaos-default
            templateType: NodeSelectorChaos
            deadline: 2m
            nodeselectorChaos:
              key: topology.kubernetes.io/zone
              selector:
                deployments:
                  nats-eks:
                    - nats-box


</details>


Observed same results as #99, except after running a cleanup step above rather than recovery.

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
