### PR TITLE
chore: use release-2.6 of dev-env and build-env images

### DIFF
--- a/.github/workflows/build_targets.yaml
+++ b/.github/workflows/build_targets.yaml
@@ -62,10 +62,10 @@ permissions: read-all
 
 jobs:
   build-images:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [amd64, arm64]
+    runs-on: ${{ fromJSON('{"amd64":"ubuntu-22.04", "arm64":"ubuntu-22.04-arm"}')[matrix.arch] }}
     env:
       TARGET_PLATFORM: ${{ matrix.arch }}
     steps:

--- a/.github/workflows/build_targets.yaml
+++ b/.github/workflows/build_targets.yaml
@@ -62,7 +62,7 @@ permissions: read-all
 
 jobs:
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -112,7 +112,7 @@ jobs:
           retention-days: 7
 
   build-e2e-binary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
           retention-days: 7
 
   build-chart:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       chart-name: ${{ steps.build-chart.outputs.chart-name }}
 
@@ -183,6 +183,6 @@ jobs:
   pass:
     needs: [build-images, build-e2e-binary, build-chart]
     name: Build passed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "🎉 Build Passed!"

--- a/.github/workflows/calculate_tag.yaml
+++ b/.github/workflows/calculate_tag.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   calculate-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: read-all
     outputs:
       tag: "${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/changed_files.yaml
+++ b/.github/workflows/changed_files.yaml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       only_changed: ${{ steps.filter.outputs.only_changed }}
     steps:

--- a/.github/workflows/check_license.yaml
+++ b/.github/workflows/check_license.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   check-license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/check_md_links.yaml
+++ b/.github/workflows/check_md_links.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       any-changed: ${{ steps.filter.outputs.any_changed }}
     steps:
@@ -27,7 +27,7 @@ jobs:
   markdown-link-check:
     needs: changed-files
     if: needs.changed-files.outputs.any-changed == 'false'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       - integration-test
       - e2e-test
     name: All Checks Pass
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           result="${{ needs.changed-files.result }}"
@@ -78,7 +78,7 @@ jobs:
           fi
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [calculate-tag, build-targets]
     permissions: write-all
     steps:

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   e2e-test-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -122,6 +122,6 @@ jobs:
     needs:
       - e2e-test-matrix
     name: E2E Test Passed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "🎉 E2E Test Passed!"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   run:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       go: ${{ steps.filter.outputs.go }}
       ui: ${{ steps.filter.outputs.ui }}
@@ -37,7 +37,7 @@ jobs:
         job:
           - verify
           - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
         job:
           - build
           - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/env-images.yaml
+++ b/env-images.yaml
@@ -17,7 +17,7 @@
 
 # specify which tag of ghcr.io/chaos-mesh/build-env image should be used with the current branch
 build-env:
-  tag: "latest"
+  tag: "release-2.6"
 # specify which tag of ghcr.io/chaos-mesh/dev-env image should be used with the current branch
 dev-env:
-  tag: "latest"
+  tag: "release-2.6"


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
